### PR TITLE
fix typo

### DIFF
--- a/scenes/README.md
+++ b/scenes/README.md
@@ -27,7 +27,7 @@ cd scenes
 This step is optional and can be skipped if you want to visualize only the particles.
 The following will create a ```.ply``` file for each input file. 
 ```bash
-./scripts/create_surface_meshes.py --input_glob "canyon_out/fluid*.npz" \
+../scripts/create_surface_meshes.py --input_glob "canyon_out/fluid*.npz" \
                                    --outdir canyon_out
 ```
 The script requires OpenVDB with python bindings.


### PR DESCRIPTION
the "cayon_out" folder should be in the "scenes/" directory, so we need to access "scripts" through ".."